### PR TITLE
Ensure inline inline code wraps on small screens

### DIFF
--- a/app/global.css
+++ b/app/global.css
@@ -47,6 +47,10 @@ html {
   @apply m-0;
 }
 
+.prose :not(pre) > code {
+  @apply break-words whitespace-normal;
+}
+
 .prose > :first-child {
   /* Override removing top margin, causing layout shift */
   margin-top: 1.25em !important;


### PR DESCRIPTION
## Summary
- apply Tailwind utilities to inline code so long strings wrap on narrow viewports
- avoid changing existing syntax-highlighted code block styling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922cce876c4832e8575c3131dc05d25)